### PR TITLE
Add PUFFDIFF operation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ once_cell = "1.21.4"
 futures-util = "0.3.32"
 lz4_flex = { version = "0.13", default-features = false, optional = true }
 bsdiff-android = { version = "0.0.2", optional = true }
+puffdiff = { version = "0.1", optional = true }
 reqwest = { version = "0.12.28", features = [
     "rustls-tls-webpki-roots",
     "stream",
@@ -85,7 +86,7 @@ hickory_dns = [
     "dep:hickory-proto",
     "reqwest?/hickory-dns",
 ]
-diff_ota = ["dep:bsdiff-android", "dep:lz4_flex"]
+diff_ota = ["dep:bsdiff-android", "dep:lz4_flex", "dep:puffdiff"]
 prefetch = ["remote_zip", "dep:tempfile"]
 
 [profile.release]

--- a/src/payload/diff.rs
+++ b/src/payload/diff.rs
@@ -336,13 +336,59 @@ pub async fn process_diff_operation(params: DiffOperationParams<'_>) -> Result<(
                 .context("Failed to write LZ4-patched data")?;
         }
 
-        install_operation::Type::Puffdiff | install_operation::Type::Lz4diffPuffdiff => {
+        install_operation::Type::Puffdiff => {
+            let source_data = ctx
+                .read_source_extents(source_file, &op.src_extents)
+                .await
+                .context("Failed to read source extents for PUFFDIFF")?;
+
+            let patch_offset = data_offset + op.data_offset.unwrap_or(0);
+            let patch_length = op.data_length.unwrap_or(0);
+
+            if patch_length > MAX_OPERATION_SIZE as u64 {
+                return Err(anyhow!("Patch size {} exceeds safety limit", patch_length));
+            }
+
+            let mut patch_stream = payload_reader
+                .read_range(patch_offset, patch_length)
+                .await
+                .context("Failed to read patch data")?;
+
+            let mut patch_data = Vec::with_capacity(patch_length as usize);
+            patch_stream
+                .read_to_end(&mut patch_data)
+                .await
+                .context("Failed to read patch stream")?;
+
+            let patched_data = puffdiff::puffpatch(&source_data, &patch_data)
+                .map_err(|e| anyhow!("PUFFDIFF patch failed: {}", e))?;
+
+            let expected_size: u64 = op
+                .dst_extents
+                .iter()
+                .map(|e| e.num_blocks.unwrap_or(0) * ctx.block_size)
+                .sum();
+
+            if patched_data.len() != expected_size as usize {
+                return Err(anyhow!(
+                    "Patched data size mismatch: expected {} bytes, got {} bytes",
+                    expected_size,
+                    patched_data.len()
+                ));
+            }
+
+            ctx.write_dst_extents(out_file, &op.dst_extents, &patched_data)
+                .await
+                .context("Failed to write PUFFDIFF data")?;
+        }
+
+        install_operation::Type::Lz4diffPuffdiff => {
             reporter.on_warning(
                 partition_name,
                 operation_index,
-                "PUFFDIFF operations not supported yet".to_string(),
+                "LZ4DIFF_PUFFDIFF operations not supported yet".to_string(),
             );
-            return Err(anyhow!("PUFFDIFF operation not supported"));
+            return Err(anyhow!("LZ4DIFF_PUFFDIFF operation not supported"));
         }
 
         install_operation::Type::Zucchini => {


### PR DESCRIPTION
## Summary

Adds support for **PUFFDIFF** install operations — the last common Android OTA
delta op type this tool didn't handle. It's used heavily on MediaTek Motorola
incrementals (and others), so `--source-dir` extraction of those payloads
previously failed on any PUFFDIFF partition.

The `Puffdiff` arm in `src/payload/diff.rs` now delegates to the
[`puffdiff`](https://crates.io/crates/puffdiff) crate — a pure-Rust port of AOSP
`external/puffin` (BSD-3-Clause) — mirroring the existing `BrotliBsdiff` arm:
read the source extents, apply the `PUF1` patch, size-check against the
destination extents, and write them out. Gated behind the existing `diff_ota`
feature.

`LZ4DIFF_PUFFDIFF` and `ZUCCHINI` remain unsupported (explicit errors), unchanged.

## The puffdiff crate

`puffdiff` is a faithful port of puffin's deflate <-> "puff" transform and the
`PUF1` container. It depends only on `bsdiff-android` (already used here), so
publishing `payload_dumper` to crates.io stays possible. It's validated:

- Bit-exact round-trip, and **byte-identical to the reference `puffin` binary**
  across stored/fixed/dynamic Huffman streams.
- Applies real PUFFDIFF operations matching the reference applier; reconstructing
  a full `boot` partition from a real incremental reproduces the payload's
  declared `new_partition_info.hash`.

## Testing

- `cargo build --release --all-features` (matches the existing CI matrix).
- End-to-end: extracting a real incremental OTA containing PUFFDIFF partitions
  now yields images whose SHA-256 match the payload's published hashes.
